### PR TITLE
switch to math.js evalutate

### DIFF
--- a/MenuPage.js
+++ b/MenuPage.js
@@ -26,96 +26,6 @@ $(document).ready(function () {
         }
     });
 
-
-    /**
-    * Replaces symbols with evaluable expressions
-    * @param {string} expression - The expression to be converted
-    * @return {string} The evaluable expression
-    */
-    function convert(expression){
-        // Part 1) Arithmetic Expressions. These expressions will involve the following symbols: (,),%,*,/,+,^ and -.
-        //         These will be evaluated using the eval function. The only problem is with the the symbol $^$. We need to convert $**$ to $^$
-        if (expression.indexOf('^') != -1) {
-            expression = expression.replace('^', '**');
-        }
-        // Part 2) Exponential, Trig and Hyperbolic functions. These expression will involve the following symbols:
-        //         exp, Currently no support for complex numbers (i)
-        //         pi, sin, cos, tan, arcsin, arccos, arctan,
-        //         sinh, cosh, tanh, arcsinh, arccosh, arctanh
-        //If there is an exponential
-        if (expression.indexOf('e') != -1) {
-            expression = expression.replace('e', 'Math.E');
-        }
-        if (expression.indexOf('exp') != -1) {
-            expression = expression.replace('exp', 'Math.E');
-        }
-        // If there is a Pi
-        if (expression.indexOf('pi') != -1) {
-            expression = expression.replace('pi', 'Math.PI');
-        }
-        // If there are trig functions
-        if (expression.indexOf('sin') != -1) {
-            expression = expression.replace('sin', 'Math.sin');
-        }
-        if (expression.indexOf('cos') != -1) {
-            expression = expression.replace('cos', 'Math.cos');
-        }
-        if (expression.indexOf('tan') != -1) {
-            expression = expression.replace('tan', 'Math.tan');
-        }
-        if (expression.indexOf('arcsin') != -1) {
-            expression = expression.replace('csrcc', 'Math.asin');
-        }
-        if (expression.indexOf('arccos') != -1) {
-            expression = expression.replace('sin', 'Math.acos');
-        }
-        if (expression.indexOf('arctan') != -1) {
-            expression = expression.replace('sin', 'Math.atan');
-        }
-        if (expression.indexOf('sinh') != -1) {
-            expression = expression.replace('sin', 'Math.sinh');
-        }
-        if (expression.indexOf('cosh') != -1) {
-            expression = expression.replace('sin', 'Math.cosh');
-        }
-        if (expression.indexOf('tanh') != -1) {
-            expression = expression.replace('sin', 'Math.tanh');
-        }
-        if (expression.indexOf('arcsinh') != -1) {
-            expression = expression.replace('sin', 'Math.asinh');
-        }
-        if (expression.indexOf('arccosh') != -1) {
-            expression = expression.replace('sin', 'Math.acosh');
-        }
-        if (expression.indexOf('arctanh') != -1) {
-            expression = expression.replace('sin', 'Math.atanh');
-        }
-        // Part 3) Logarithms:
-        // Natural log as ln and log base 10 as log
-        if (expression.indexOf('log') != -1) {
-            expression = expression.replace('log', 'Math.log10');
-        }
-        if (expression.indexOf('ln') != -1) {
-            expression = expression.replace('ln', 'Math.log');
-        }
-        //Part 4) Special functions:
-        // sqrt, max, min, abs
-        if (expression.indexOf('sqrt') != -1) {
-            expression = expression.replace('sqrt', 'Math.sqrt');
-        }
-        if (expression.indexOf('max') != -1) {
-            expression = expression.replace('max', 'Math.max');
-        }
-        if (expression.indexOf('min') != -1) {
-            expression = expression.replace('min', 'Math.min');
-        }
-        if (expression.indexOf('abs') != -1) {
-            expression = expression.replace('abs', 'Math.abs');
-        }
-        
-        return expression;
-    };
-
     /**
     * Evalueate the expression
     */
@@ -191,18 +101,17 @@ $(document).ready(function () {
 
         // Otherwise the expression will be converted and evaluated using eval method in Javascript
         else{
-            expression = convert(exp);
-        try {
-            var node1 = document.createTextNode("$"+eval(expression)+"$");
-            para.appendChild(child1);
-            para.appendChild(node1);
-        }
-        catch (err) {
-            $("#data").effect("shake", "slow");
-            var node2 = document.createTextNode("I can't solve ");
-            para.appendChild(node2);
-            para.appendChild(child2);
-        }
+            try {
+                var node1 = document.createTextNode("$"+math.eval(exp)+"$");
+                para.appendChild(child1);
+                para.appendChild(node1);
+            }
+            catch (err) {
+                $("#data").effect("shake", "slow");
+                var node2 = document.createTextNode("I can't solve ");
+                para.appendChild(node2);
+                para.appendChild(child2);
+            }
         }
         var element = document.getElementById("output");
         element.appendChild(para);        


### PR DESCRIPTION
Use math.js eval function rather than converting expression to be handled by default JS eval(). Math.js handles all of the operations that the convert function did, plus others, such as factorials.
Fixes #15 